### PR TITLE
Fixed a typo in documentation

### DIFF
--- a/R/DES.R
+++ b/R/DES.R
@@ -51,7 +51,7 @@
 
 #    matrix in simlist
 #    one row for each event, rows ordered by event occurrence time
-#    first two cols are event time, event time, then app-specific info
+#    first two cols are event time, event type, then app-specific info
 
 # outline of a typical application:
 

--- a/R/DES.R.plot
+++ b/R/DES.R.plot
@@ -51,7 +51,7 @@
 
 #    matrix in simlist
 #    one row for each event, rows ordered by event occurrence time
-#    first two cols are event time, event time, then app-specific info
+#    first two cols are event time, event type, then app-specific info
 
 # outline of a typical application:
 


### PR DESCRIPTION
Changed a repeated 'event time' to 'event type' on a line explaining the columns of an event.